### PR TITLE
Fix/installments option

### DIFF
--- a/assets/admin-settings-schema.json
+++ b/assets/admin-settings-schema.json
@@ -43,7 +43,7 @@
                 "title": "The Name Schema",
                 "default": "",
                 "examples": [
-                  "Cartão Credito"
+                  "Cartão de crédito"
                 ],
                 "pattern": "^(.*)$"
               },

--- a/lib/payment-default.js
+++ b/lib/payment-default.js
@@ -5,7 +5,7 @@
 module.exports = {
   payment_options: [
     {
-      name: 'Cartão Credito',
+      name: 'Cartão de crédito',
       type: 'credit_card',
       payment_type: 'payment',
       installments: [

--- a/routes/ecom/modules/list-payments.js
+++ b/routes/ecom/modules/list-payments.js
@@ -90,9 +90,9 @@ module.exports = () => {
             ...newPaymentGateway(),
             payment_method: {
               code: 'credit_card',
-              name: 'Cartão Credito'
+              name: 'Cartão de crédito - Moip'
             },
-            label: 'Cartão Credito',
+            label: 'Cartão de crédito',
             installment_options: [],
             js_client: {
               cc_brand: {

--- a/routes/ecom/modules/list-payments.js
+++ b/routes/ecom/modules/list-payments.js
@@ -132,10 +132,18 @@ module.exports = () => {
             }
 
             // installments_option
-            response.installments_option = {
-              min_installment: installments.min_installment,
-              max_number: installments.max_number,
-              monthly_interest: installments.monthly_interest
+            if (installments.max_number_w_tax > 0) {
+              response.installments_option = {
+                min_installment: installments.min_installment,
+                max_number: installments.max_number_w_tax,
+                monthly_interest: 0
+              }
+            } else {
+              response.installments_option = {
+                min_installment: installments.min_installment,
+                max_number: installments.max_number_w_tax,
+                monthly_interest: installments.tax_value
+              }
             }
           } else {
             // wirecard default installments

--- a/routes/ecom/modules/list-payments.js
+++ b/routes/ecom/modules/list-payments.js
@@ -132,7 +132,7 @@ module.exports = () => {
             }
 
             // installments_option
-            if (installments.max_number_w_tax > 0) {
+            if (installments.max_number_w_tax >= 2) {
               response.installments_option = {
                 min_installment: installments.min_installment,
                 max_number: installments.max_number_w_tax,
@@ -141,7 +141,7 @@ module.exports = () => {
             } else {
               response.installments_option = {
                 min_installment: installments.min_installment,
-                max_number: installments.max_number_w_tax,
+                max_number: installments.max_number,
                 monthly_interest: installments.tax_value
               }
             }


### PR DESCRIPTION
Fixando o erro apontado em https://community.e-com.plus/t/wirecard-configuracoes/204/4

> Não está calculando o juros das parcelas na apresentação do produto mesmo sendo definido no aplicativo que não há parcelas sem juros e colocando a taxa! Somente na finalização está aparecendo

Aproveitei pra corrigir uns typos aí (acento em _crédito_).